### PR TITLE
server: Include '%d of %d streams healthy' in top-level context

### DIFF
--- a/main.go
+++ b/main.go
@@ -125,11 +125,11 @@ func addSharedFlags(flagset *pflag.FlagSet, o *options) {
 }
 
 func (o *options) runReport() error {
-	report, err := generateReport(o.releaseAPIUrl, o.acceptedStalenessLimit, o.builtStalenessLimit, o.upgradeStalenessLimit, o.oldestMinor, o.newestMinor, o.includeHealthy)
+	report, err := generateReport(o.releaseAPIUrl, o.acceptedStalenessLimit, o.builtStalenessLimit, o.upgradeStalenessLimit, o.oldestMinor, o.newestMinor)
 	if err != nil {
 		return err
 	}
-	fmt.Println(report)
+	fmt.Println(report.String(o.includeHealthy))
 	return nil
 }
 


### PR DESCRIPTION
Return a structured report from `generateReport`, so consumers like `createHandler` can extract metadata like the number of healthy streams. Including this in the top-level thread post gives folks an idea of how important it is to drop into the thread for details (e.g. no need to drop in if the threads are all healthy).

Also fix threading for `help` responses and similar, by [carrying through the message timestamp][1] from the triggering event [1].

[1]: https://api.slack.com/messaging/sending#threading