### PR TITLE
Automatically discover the oldest and newest minor versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ https://amd64.ocp.releases.ci.openshift.org/#4.9.0-0.nightly
 
 * --accepted-staleness-limit duration   How old an accepted payload can be before it is considered stale (default 24h0m0s)
 * --built-staleness-limit duration      How old an built payload can be before it is considered stale (default 72h0m0s)
-* --newest-minor int                    The newest minor release to analyze.  Release streams newer than this will be ignored.  Specify only the minor value (e.g. "12") (default 12)
-* --oldest-minor int                    The oldest minor release to analyze.  Release streams older than this will be ignored.  Specify only the minor value (e.g. "9") (default 9)
+* --newest-minor int                    The newest minor release to analyze.  Release streams newer than this will be ignored.  Specify only the minor value (e.g. "12") (default to looking up the newest supported release)
+* --oldest-minor int                    The oldest minor release to analyze.  Release streams older than this will be ignored.  Specify only the minor value (e.g. "9") (default to looking up the oldest supported release)
 * --release-api-url string              The url of the release reporting api (default "https://amd64.ocp.releases.ci.openshift.org")
 * --upgrade-staleness-limit duration    How old a successful upgrade attempt can be before it's considered stale (default 72h0m0s)
 

--- a/life_cycle.go
+++ b/life_cycle.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"k8s.io/klog"
+)
+
+type productLifeCycleResponse struct {
+	Data []productLifeCycle `json:"data"`
+}
+
+type productLifeCycle struct {
+	Name     string                    `json:"name"`
+	Versions []productLifeCycleVersion `json:"versions"`
+}
+
+type productLifeCycleVersion struct {
+	Name string `json:"name"`
+	Type string `json:"type:`
+}
+
+func getSupportedReleases(url string) (int, int, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return 0, 0, fmt.Errorf("error fetching life-cycle data from %s: %s", url, err)
+	}
+	if resp.StatusCode != 200 {
+		return 0, 0, fmt.Errorf("non-OK http response code from %s: %d", url, resp.StatusCode)
+	}
+	defer resp.Body.Close()
+
+	data := productLifeCycleResponse{}
+	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return 0, 0, fmt.Errorf("error decoding life-cycle data from %s: %s", url, err)
+	}
+
+	if len(data.Data) != 1 {
+		return 0, 0, fmt.Errorf("life-cycle data from %s contains %d products, but should only contain 1", url)
+	}
+
+	minSupportedRelease := -1
+	maxSupportedRelease := -1
+	for _, version := range data.Data[0].Versions {
+		if version.Type == "End of life" {
+			continue
+		}
+		entries := strings.Split(version.Name, ".")
+		if len(entries) != 2 {
+			klog.V(4).Infof("expected one period in %q for parsing a minor version", version.Name)
+			continue
+		}
+		if entries[0] != "4" {
+			klog.V(4).Infof("expected major version 4 in %q, not %q", version.Name, entries[0])
+			continue
+		}
+
+		minor, err := strconv.Atoi(entries[1])
+		if err != nil {
+			klog.V(4).Infof("expected integer minor version in %q, not %q: %v", version.Name, entries[1], err)
+			continue
+		}
+
+		if minSupportedRelease == -1 || minSupportedRelease > minor {
+			minSupportedRelease = minor
+		}
+		if maxSupportedRelease == -1 || maxSupportedRelease < minor {
+			maxSupportedRelease = minor
+		}
+	}
+
+	if minSupportedRelease == -1 {
+		return 0, 0, fmt.Errorf("life-cycle data from %s contains no supported releases for %s", url, data.Data[0].Name)
+	}
+
+	return minSupportedRelease, maxSupportedRelease, nil
+}

--- a/main.go
+++ b/main.go
@@ -89,9 +89,6 @@ func newReportCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if o.oldestMinor < 0 || o.newestMinor < 0 || (o.newestMinor < o.oldestMinor) {
-				return fmt.Errorf("invalid release range (%d -> %d), release versions must be non-negative and newest must be greater than oldest", o.oldestMinor, o.newestMinor)
-			}
 			return o.runReport()
 		},
 	}
@@ -109,9 +106,6 @@ func newBotCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if o.oldestMinor < 0 || o.newestMinor < 0 || (o.newestMinor < o.oldestMinor) {
-				return fmt.Errorf("invalid release range (%d -> %d), release versions must be non-negative and newest must be greater than oldest", o.oldestMinor, o.newestMinor)
-			}
 			return o.runBot()
 		},
 	}
@@ -123,8 +117,8 @@ func newBotCommand() *cobra.Command {
 }
 
 func addSharedFlags(flagset *pflag.FlagSet, o *options) {
-	flagset.IntVar(&o.oldestMinor, "oldest-minor", -1, "The oldest minor release to analyze.  Release streams older than this will be ignored.  Specify only the minor value (e.g. \"9\")")
-	flagset.IntVar(&o.newestMinor, "newest-minor", -1, "The newest minor release to analyze.  Release streams newer than this will be ignored.  Specify only the minor value (e.g. \"12\")")
+	flagset.IntVar(&o.oldestMinor, "oldest-minor", -1, "The oldest minor release to analyze.  Release streams older than this will be ignored.  Specify only the minor value (e.g. \"9\") (default to looking up the newest supported release)")
+	flagset.IntVar(&o.newestMinor, "newest-minor", -1, "The newest minor release to analyze.  Release streams newer than this will be ignored.  Specify only the minor value (e.g. \"12\") (default to looking up the newest supported release)")
 	flagset.DurationVar(&o.acceptedStalenessLimit, "accepted-staleness-limit", 24*time.Hour, "How old an accepted payload can be before it is considered stale")
 	flagset.DurationVar(&o.builtStalenessLimit, "built-staleness-limit", 72*time.Hour, "How old an built payload can be before it is considered stale")
 	flagset.DurationVar(&o.upgradeStalenessLimit, "upgrade-staleness-limit", 72*time.Hour, "How old a successful upgrade attempt can be before it's considered stale")

--- a/report.go
+++ b/report.go
@@ -139,6 +139,8 @@ func getReleaseStream(url string) (map[string][]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error fetching releases from %s: %s", url, err)
 	}
+	defer res.Body.Close()
+
 	if res.StatusCode != 200 {
 		return nil, fmt.Errorf("non-OK http response code from %s: %d", url, res.StatusCode)
 	}
@@ -247,6 +249,8 @@ func getUpgradeGraph(apiurl, channel string) (GraphMap, error) {
 	if err != nil {
 		return graphMap, fmt.Errorf("error fetching upgrade graph from %s: %s", url, err)
 	}
+	defer res.Body.Close()
+
 	if res.StatusCode != 200 {
 		return graphMap, fmt.Errorf("non-OK http response code fetching upgrade graph from %s: %d", url, res.StatusCode)
 	}

--- a/report.go
+++ b/report.go
@@ -25,6 +25,21 @@ type report struct {
 }
 
 func generateReport(acceptedStalenessLimit, builtStalenessLimit, upgradeStalenessLimit time.Duration, oldestMinor, newestMinor int, arch string) (*report, error) {
+	if oldestMinor == -1 || newestMinor == -1 {
+		oldestSupportedMinor, newestSupportedMinor, err := getSupportedReleases("https://access.redhat.com/product-life-cycles/api/v1/products?name=Openshift%20Container%20Platform%204")
+		if err != nil {
+			return nil, err
+		}
+		if oldestMinor == -1 {
+			oldestMinor = oldestSupportedMinor
+		}
+		if newestMinor == -1 {
+			newestMinor = newestSupportedMinor
+		}
+		if oldestMinor < 0 || newestMinor < 0 || newestMinor < oldestMinor {
+			return nil, fmt.Errorf("invalid release range (%d -> %d), release versions must be non-negative and newest must be greater than oldest", oldestMinor, newestMinor)
+		}
+	}
 
 	releaseAPIUrl, found := releaseAPIUrls[arch]
 	if !found {

--- a/server.go
+++ b/server.go
@@ -237,6 +237,7 @@ func sendMessage(msg, channel, thread string) (string, error) {
 		fmt.Printf("error posting chat message: %v", err)
 		return "", err
 	}
+	defer resp.Body.Close()
 	// fmt.Printf("chat message response: %#v\n", resp)
 
 	body, err := ioutil.ReadAll(resp.Body)
@@ -249,6 +250,5 @@ func sendMessage(msg, channel, thread string) (string, error) {
 		fmt.Printf("error reading message response body: %v\n", err)
 		return "", err
 	}
-	resp.Body.Close()
 	return msgResp.TS, nil
 }


### PR DESCRIPTION
Consuming:

```console
$ curl -s 'https://access.redhat.com/product-life-cycles/api/v1/products?name=Openshift%20Container%20Platform%204' | jq -c '.data[].versions[] | select(.type != "End of life") | {name, type}'
{"name":"4.13","type":"Full Support"}
{"name":"4.12","type":"Maintenance Support"}
{"name":"4.11","type":"Maintenance Support"}
```

So we don't have to bump these in [the deployed bot][1], which is currently stale:

```console
$ oc -n bparees get -o json deployment release-watcher | jq -c '.spec.template.spec.containers[].args'
["bot","--oldest-minor","10","--newest-minor","13"]
```

[1]: https://github.com/openshift/release/tree/2fe8e522c053e3a8323dab8449df9a377bee96f6/clusters/app.ci/bparees